### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/test/DotNet.Core.Runtime.Faker.Integration.Tests/DotNet.Core.Runtime.Faker.Integration.Tests.csproj
+++ b/test/DotNet.Core.Runtime.Faker.Integration.Tests/DotNet.Core.Runtime.Faker.Integration.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="33.0.1" />
+    <PackageReference Include="Bogus" Version="33.0.2" />
     <PackageReference Include="FakeItEasy" Version="6.2.1" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
-    <PackageReference Include="nunit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.7" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi@willsbctm, I found an issue in the DotNet.Core.Runtime.Faker.Integration.Tests.csproj:

Packages Bogus v33.0.1, Microsoft.AspNetCore.Mvc.Testing v3.1.5, nunit v3.13.1, NUnit3TestAdapter v3.17.0 and Microsoft.NET.Test.Sdk v16.8.3 transitively introduce 103 dependencies into DotNet.Core.Runtime.Faker’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/DotNet-Core-Runtime-Faker.html)), while Bogus v33.0.2, Microsoft.AspNetCore.Mvc.Testing v3.1.7, nunit v3.13.2, NUnit3TestAdapter v4.0.0 and Microsoft.NET.Test.Sdk v16.9.1 can only introduce 61 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/DotNet-Core-Runtime-Faker_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose